### PR TITLE
Set top-level environment to package namespace when running tests.

### DIFF
--- a/R/testit.R
+++ b/R/testit.R
@@ -95,7 +95,7 @@ test_pkg = function(package, dir = 'testit') {
   for (r in rs) {
     rm(list = ls(env, all.names = TRUE), envir = env)
     withCallingHandlers(
-      sys.source(r, envir = env, chdir = TRUE, keep.source = TRUE),
+      sys.source.topenv(r, envir = env, top.env = getNamespace(package)),
       error = function(e) {
         message(r, ':')
       }


### PR DESCRIPTION
This patch ensures that test_pkg runs package tests with top-level environment being set to the namespace of the tested package. This makes the environment structure more similar to real execution of package code. This patch is necessary to make testit work with the R byte-code compiler, which is less permissive on the environment structure than the R AST interpreter.

A similar solution is used in testthat (see sys.source2, with_top_env functions), yet overall testthat uses a more complicated way of setting up environments for running packages (e.g. to support S4, functions - see test_pkg_env).
