### PR TITLE
Expose silent argument in has_error()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,10 @@ Package: testit
 Type: Package
 Title: A Simple Package for Testing R Packages
 Version: 0.8
-Authors@R:
-  person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666"))
+Authors@R: c(
+  person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")), 
+  person("Steven", "Mortimer", , email="reportmort@gmail.com", role="ctb")
+  )
 Description: Provides two convenience functions assert() and test_pkg() to
     facilitate testing R packages.
 License: GPL

--- a/R/testit.R
+++ b/R/testit.R
@@ -196,12 +196,13 @@ test_pkg = function(package, dir = 'testit') {
 #' The two functions \code{has_warning()} and \code{has_error()} check if an
 #' expression produces warnings and errors, respectively.
 #' @param expr an R expression
+#' @param silent logical: should the report of error messages be suppressed?
 #' @return A logical value.
 #' @export
 #' @rdname has_message
 #' @examples has_warning(1+1); has_warning(1:2+1:3)
 #'
-#' has_error(2-3); has_error(1+'a')
+#' has_error(2-3); has_error(1+'a'); has_error(stop("err"), silent = TRUE)
 has_warning = function(expr) {
   warn = FALSE
   op = options(warn = -1); on.exit(options(op))
@@ -213,6 +214,6 @@ has_warning = function(expr) {
 }
 #' @export
 #' @rdname has_message
-has_error = function(expr) {
-  inherits(try(force(expr), silent = !interactive()), 'try-error')
+has_error = function(expr, silent = !interactive()) {
+  inherits(try(force(expr), silent = silent), 'try-error')
 }

--- a/man/has_message.Rd
+++ b/man/has_message.Rd
@@ -7,10 +7,12 @@
 \usage{
 has_warning(expr)
 
-has_error(expr)
+has_error(expr, silent = !interactive())
 }
 \arguments{
 \item{expr}{an R expression}
+
+\item{silent}{logical: should the report of error messages be suppressed?}
 }
 \value{
 A logical value.
@@ -25,4 +27,5 @@ has_warning(1:2 + 1:3)
 
 has_error(2 - 3)
 has_error(1 + "a")
+has_error(stop("err"), silent = TRUE)
 }

--- a/tests/testit/test-assert.R
+++ b/tests/testit/test-assert.R
@@ -37,6 +37,12 @@ assert(
   has_error(1 + 'a')
 )
 
+assert(
+  'has_error() can suppress error message',
+  has_error(stop('An intentional error'), silent = TRUE),
+  has_error(1 + 'a', silent = FALSE)
+)
+
 assert('tests can be written in () in a single {}', {
 
   (1 == 1L)


### PR DESCRIPTION
Allow the user the option of controlling the silent argument in `has_error()` and revert to the default behavior when it is not specified

Closes #5