### PR TITLE
Document that library(testit) is required before test_pkg()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: testit
 Type: Package
 Title: A Simple Package for Testing R Packages
-Version: 0.18.10
+Version: 0.18.11
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
   person("Tomas", "Kalibera", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN testit VERSION 0.19
 
+- Documented that `library(testit)` is required before calling `test_pkg()`, since test scripts call `assert()` and other functions directly without the `testit::` prefix (#XX).
+
 - `test_pkg()` gained a `filter` argument that takes a regular expression to selectively run a subset of test files (e.g., `test_pkg(filter = 'parse')` runs only files with "parse" in their names).
 
 - `test_pkg()` now runs all test files instead of stopping at the first failure. Errors are collected and reported together at the end, including multiple errors within a single file (thanks, @jdblischak, #19). The relative filename of each test is printed before execution.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # CHANGES IN testit VERSION 0.19
 
-- Documented that `library(testit)` is required before calling `test_pkg()`, since test scripts call `assert()` and other functions directly without the `testit::` prefix (#XX).
-
 - `test_pkg()` gained a `filter` argument that takes a regular expression to selectively run a subset of test files (e.g., `test_pkg(filter = 'parse')` runs only files with "parse" in their names).
 
 - `test_pkg()` now runs all test files instead of stopping at the first failure. Errors are collected and reported together at the end, including multiple errors within a single file (thanks, @jdblischak, #19). The relative filename of each test is printed before execution.

--- a/R/testit.R
+++ b/R/testit.R
@@ -191,10 +191,20 @@ assert2 = function(fact, exprs, envir, all = TRUE, loc = NULL) {
 #' @return \code{NULL}. All test files are executed and errors are collected; if
 #'   any tests fail, a single error is thrown at the end with all failure
 #'   messages combined.
-#' @note All test scripts must be encoded in UTF-8 if they contain any multibyte
+#' @note The \pkg{testit} package must be loaded (e.g., via
+#'   \code{library(testit)}) before calling \code{test_pkg()}, because test
+#'   scripts typically call \code{\link{assert}()} and other \pkg{testit}
+#'   functions directly without the \code{testit::} prefix. Simply using
+#'   \code{testit::test_pkg()} without loading the package first will result in
+#'   errors like \dQuote{could not find function "assert"}.
+#'
+#' All test scripts must be encoded in UTF-8 if they contain any multibyte
 #'   characters.
 #' @export
-#' @examples \dontrun{test_pkg('testit')}
+#' @examples \dontrun{
+#' library(testit)
+#' test_pkg('testit')
+#' }
 test_pkg = function(package = pkg_name(), dir = NULL, filter = NULL, update = NA) {
   # install the source package before running tests when this function is called
   # in a non-interactive R session that is not `R CMD check`

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This package provides two simple functions:
   the package namespace directly available, so no need to use the triple-colon
   `package:::name` for non-exported objects
 
-Snapshot testing is also supported via markdown files in `_snapshots/`
-directories.
+Snapshot testing is also supported via markdown files (`test-*.md`) in the same
+test directory.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ library(testit)
 test_pkg('pkg_name')
 ```
 
+Note that `library(testit)` is required here because test scripts call
+`assert()` and other **testit** functions directly (without the `testit::`
+prefix). Using `testit::test_pkg()` alone without loading the package first will
+result in errors like "could not find function `assert`".
+
 That is all for `R CMD check`. For package development, you can
 `Ctrl/Cmd + Shift + T` to run tests.
 

--- a/man/test_pkg.Rd
+++ b/man/test_pkg.Rd
@@ -60,9 +60,19 @@ See \url{https://pkg.yihui.org/testit/#snapshot-testing} for more details
 about snapshot testing.
 }
 \note{
+The \pkg{testit} package must be loaded (e.g., via
+  \code{library(testit)}) before calling \code{test_pkg()}, because test
+  scripts typically call \code{\link{assert}()} and other \pkg{testit}
+  functions directly without the \code{testit::} prefix. Simply using
+  \code{testit::test_pkg()} without loading the package first will result in
+  errors like \dQuote{could not find function "assert"}.
+
 All test scripts must be encoded in UTF-8 if they contain any multibyte
   characters.
 }
 \examples{
-\dontrun{test_pkg('testit')}
+\dontrun{
+library(testit)
+test_pkg('testit')
+}
 }


### PR DESCRIPTION
## Summary

- Added a `@note` to `test_pkg()` help page explaining that `library(testit)` must be called before `test_pkg()`, since test scripts call `assert()` and other functions without the `testit::` prefix
- Added the same explanation to the README in the "R CMD check" section
- Updated the `@examples` in `test_pkg()` to show `library(testit)` before `test_pkg()`
- Bumped version to 0.18.11

Closes a documentation gap where users calling `testit::test_pkg()` without loading the package first get confusing "could not find function" errors.

## Test plan

- [x] `R CMD check` passes cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)