### PR TITLE
Improve documentation and fix ignore.case bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,18 @@
 Package: testit
 Type: Package
 Title: A Simple Package for Testing R Packages
-Version: 0.18.12
+Version: 0.18.13
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
   person("Tomas", "Kalibera", role = "ctb"),
   person("Steven", "Mortimer", role = "ctb", email="reportmort@gmail.com")
   )
-Description: Provides two convenience functions assert() and test_pkg() to
-    facilitate testing R packages.
+Description: A minimal, dependency-free testing framework for R packages.
+    Write tests as simple R expressions that return TRUE, using assert() for
+    assertions (with informative error messages on failure), has_error() /
+    has_warning() / has_message() for testing conditions, and test_pkg() to
+    run all tests with full access to internal (non-exported) package
+    functions. Snapshot testing via Markdown files is also supported.
 License: MIT + file LICENSE
 URL: https://github.com/yihui/testit
 BugReports: https://github.com/yihui/testit/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,5 @@ License: MIT + file LICENSE
 URL: https://github.com/yihui/testit
 BugReports: https://github.com/yihui/testit/issues
 Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,5 @@
 # CHANGES IN testit VERSION 0.19
 
-- Improved documentation throughout: README rewritten to be more beginner-friendly with a quick-start guide and clearer examples; roxygen docs rewritten for clarity; DESCRIPTION now describes the full feature set.
-
-- Fixed `has_message()`, `has_warning()`, and `has_error()` to correctly support `ignore.case = TRUE`. Previously, `ignore.case` was silently ignored because `fixed = TRUE` (the default) takes precedence in `grepl()`. Now, passing `ignore.case = TRUE` automatically disables fixed matching.
-
 - `test_pkg()` gained a `filter` argument that takes a regular expression to selectively run a subset of test files (e.g., `test_pkg(filter = 'parse')` runs only files with "parse" in their names).
 
 - `test_pkg()` now runs all test files instead of stopping at the first failure. Errors are collected and reported together at the end, including multiple errors within a single file (thanks, @jdblischak, #19). The relative filename of each test is printed before execution.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN testit VERSION 0.19
 
+- Improved documentation throughout: README rewritten to be more beginner-friendly with a quick-start guide and clearer examples; roxygen docs rewritten for clarity; DESCRIPTION now describes the full feature set.
+
+- Fixed `has_message()`, `has_warning()`, and `has_error()` to correctly support `ignore.case = TRUE`. Previously, `ignore.case` was silently ignored because `fixed = TRUE` (the default) takes precedence in `grepl()`. Now, passing `ignore.case = TRUE` automatically disables fixed matching.
+
 - `test_pkg()` gained a `filter` argument that takes a regular expression to selectively run a subset of test files (e.g., `test_pkg(filter = 'parse')` runs only files with "parse" in their names).
 
 - `test_pkg()` now runs all test files instead of stopping at the first failure. Errors are collected and reported together at the end, including multiple errors within a single file (thanks, @jdblischak, #19). The relative filename of each test is printed before execution.

--- a/R/testit.R
+++ b/R/testit.R
@@ -25,8 +25,8 @@
 #' - `assert()` shows your custom `fact` message on failure, making errors
 #'   easier to diagnose.
 #' - `logical(0)` (empty logical) is treated as a failure, not a pass.
-#' - Assertions are evaluated sequentially; `assert()` stops at the first
-#'   failure and reports it.
+#' - All conditions are evaluated even if earlier ones fail; all failures are
+#'   reported together in a single error message.
 #' @export
 #' @examples
 #' library(testit)

--- a/R/testit.R
+++ b/R/testit.R
@@ -326,7 +326,8 @@ error_loc = function(x, line = 1) {
 #'   when the condition is signaled \emph{and} the message matches.
 #' @param ... additional arguments passed to \code{\link{grepl}()} for matching
 #'   \code{message} against the condition message (e.g., \code{fixed = TRUE} for
-#'   fixed string matching, or \code{ignore.case = TRUE}).
+#'   fixed string matching, or \code{ignore.case = TRUE}). Note that \code{fixed
+#'   = TRUE} is the default.
 #' @return A logical value.
 #' @export
 #' @rdname has_message
@@ -374,8 +375,10 @@ has_error = function(expr, message = NULL, ...) {
 
 match_cond = function(text, message, ...) {
   if (is.null(text)) FALSE else if (is.null(message)) TRUE else
-    grepl(message, text, ...)
+    grepl2(message, text, ...)
 }
+
+grepl2 = function(..., fixed = TRUE) grepl(..., fixed = fixed)
 
 quietly = function(expr) {
   withCallingHandlers(

--- a/R/testit.R
+++ b/R/testit.R
@@ -1,34 +1,32 @@
-#' Assertions with an optional message
+#' Assert that conditions are true, with an informative failure message
 #'
-#' The function `assert()` was inspired by [stopifnot()]. It emits a message in
-#' case of errors, which can be a helpful hint for diagnosing the errors
-#' (`stopifnot()` only prints the possibly truncated source code of the
-#' expressions).
+#' Test that one or more conditions are `TRUE`. If any condition fails, an error
+#' is raised with the `fact` message, making it easy to identify which test
+#' failed and why. This is the primary function for writing tests with
+#' **testit**.
 #'
-#' For the `...` argument, it should be a single R expression wrapped in `{}`.
-#' This expression may contain multiple sub-expressions. A sub-expression is
-#' treated as a test condition if it is wrapped in `()` (meaning its value will
-#' be checked to see if it is a logical vector containing any `FALSE` values) ,
-#' otherwise it is evaluated in the normal way and its value will not be
-#' checked. If the value of the last sub-expression is logical, it will also be
-#' treated as a test condition.
-#' @param fact A message for the assertions when any of them fails; treated the
-#'   same way as expressions in `...` if it is not a character string, which
-#'   means you are not required to provide a message to this function.
-#' @param ... An R expression; see Details.
-#' @return For `assert()`, invisible `NULL` if all expressions returned `TRUE`,
-#'   otherwise an error is signaled and the user-provided message is emitted.
-#'   For `%==%`, `TRUE` or `FALSE`.
-#' @note The internal implementation of `assert()` is different with the
-#'   `stopifnot()` function in R **base**: (1) the custom message `fact` is
-#'   emitted if an error occurs; (2) `assert()` requires the logical values to
-#'   be non-empty (`logical(0)` will trigger an error); (3) if `...` contains a
-#'   compound expression in `{}` that returns `FALSE` (e.g., `if (TRUE) {1+1;
-#'   FALSE}`), the first and the last but one line of the source code from
-#'   [deparse()] are printed in the error message, otherwise the first line is
-#'   printed; (4) the arguments in `...` are evaluated sequentially, and
-#'   `assert()` will signal an error upon the first failed assertion, and will
-#'   ignore the rest of assertions.
+#' The recommended usage is to pass a single expression wrapped in `{}` as the
+#' second argument. Inside `{}`, any sub-expression wrapped in parentheses `()`
+#' is treated as a test condition -- its value is checked and must be `TRUE`.
+#' Sub-expressions *without* parentheses are ordinary R code (e.g., variable
+#' assignments or setup steps) and their values are not checked. The last
+#' sub-expression is also treated as a test condition if it returns a logical
+#' value, even without explicit parentheses.
+#' @param fact A character string describing what is being tested. This message
+#'   is shown when an assertion fails, so make it descriptive (e.g., `'log()
+#'   returns correct values'`). If `fact` is not a character string, it is
+#'   treated as a test expression (i.e., the message is optional).
+#' @param ... An R expression wrapped in `{}`; see Details.
+#' @return Invisible `NULL` if all conditions pass. If any condition fails, an
+#'   error is signaled that includes the `fact` message and the expression that
+#'   failed. For `%==%`, `TRUE` or `FALSE`.
+#' @note Key differences from [stopifnot()]:
+#'
+#' - `assert()` shows your custom `fact` message on failure, making errors
+#'   easier to diagnose.
+#' - `logical(0)` (empty logical) is treated as a failure, not a pass.
+#' - Assertions are evaluated sequentially; `assert()` stops at the first
+#'   failure and reports it.
 #' @export
 #' @examples
 #' library(testit)
@@ -113,13 +111,12 @@ assert2 = function(fact, exprs, envir, all = TRUE, loc = NULL) {
   if (length(errs)) stop(paste(errs, collapse = '\n'), call. = FALSE, domain = NA)
 }
 
-#' @description The infix operator `%==%` is simply an alias of the
-#'   [identical()] function to make it slightly easier and intuitive to write
-#'   test conditions. `x %==% y` is the same as `identical(x, y)`. When it is
-#'   used inside `assert()`, a message will be printed if the returned value is
-#'   not `TRUE`, to show the values of the LHS (`x`) and RHS (`y`) via
-#'   [str()], which can be helpful for you to check why the assertion failed.
-#' @param x,y two R objects to be compared
+#' @description The infix operator `%==%` is a shortcut for [identical()] that
+#'   provides helpful diagnostics on failure. `x %==% y` returns `TRUE` if `x`
+#'   and `y` are identical, and `FALSE` otherwise. When used inside `assert()`,
+#'   a failing `%==%` comparison will display both values via [str()] so you can
+#'   see exactly what differed.
+#' @param x,y Two R objects to be compared for identity.
 #' @rdname assert
 #' @import utils
 #' @export
@@ -144,56 +141,48 @@ assert2 = function(fact, exprs, envir, all = TRUE, loc = NULL) {
   res
 }
 
-#' Run the tests of a package in its namespace
+#' Run all tests for a package
 #'
-#' The tests are executed in a clean environment with the namespace of the
-#' package to be tested as the parent environment, which means you can use
-#' non-exported objects in the package without having to resort to the triple
-#' colon `:::` trick.
+#' Discover and execute test files (`test-*.R` and `test-*.md`) for a package.
+#' Tests are run inside the package namespace, so you can call internal
+#' (non-exported) functions directly without the `:::` operator.
 #'
-#' The tests are assumed to be under the `testit/` or `tests/testit/` directory
-#' by default (depending on your working directory is the package root directory
-#' or the `tests/` directory). The test scripts must be named of the form
-#' `test-*.R` (or `test-*.md` for snapshot tests); other files will not be
-#' treated as test files (but may also be useful, e.g. you can [source()] other
-#' scripts in tests).
+#' Test files are looked up in the `testit/` or `tests/testit/` directory by
+#' default. Files must be named `test-*.R` for regular tests or `test-*.md` for
+#' snapshot tests. Other files in the directory are ignored (but you can
+#' [source()] them from your tests if needed).
 #'
 #' Helper files named `helper*.R` (e.g., `helper.R`, `helper-utils.R`) are
-#' sourced before test files and remain available to all tests, allowing you to
-#' define shared utility functions.
+#' sourced before any test file runs. Objects defined in helpers are available
+#' to all tests.
 #'
-#' When a test is executed, the working directory is the same as the directory
-#' containing this test, and all existing objects in the test environment will
-#' be removed before the code is executed (except for helper functions).
+#' Each test file runs in a clean environment (previous test objects are
+#' removed), and the working directory is set to the directory containing the
+#' test file.
 #'
 #' See <https://pkg.yihui.org/testit/#snapshot-testing> for more details about
 #' snapshot testing.
 #' @param package The package name. By default, it is detected from the
-#'   `DESCRIPTION` file if exists.
-#' @param dir The directory of the test files. If `NULL` (the default), the
-#'   directory `testit/` or `tests/testit/` under the current working directory
-#'   is used (whichever exists). You can also specify a custom directory.
+#'   `DESCRIPTION` file.
+#' @param dir The directory containing test files. If `NULL` (the default),
+#'   `testit/` or `tests/testit/` under the current working directory is used
+#'   (whichever exists). You can also pass a custom path.
 #' @param filter An optional regular expression to select a subset of test
-#'   files. Only files whose names (without directory) match the pattern will be
-#'   run. For example, `filter = "parse"` runs only test files with "parse" in
-#'   their names.
-#' @param update If `TRUE`, update snapshot files with actual output instead of
-#'   comparing. If `NA` (the default), update snapshot files only if they are
-#'   tracked by GIT (so you can view the diffs in GIT and decide whether to
-#'   accept or discard the changes). If `FALSE`, never update snapshot files and
-#'   always compare. For `NA` and `FALSE`, if the snapshot test fails, it will
-#'   throw an error with a message showing the location of the failed test. For
-#'   `TRUE`, it will update the snapshot file and never throw an error.
-#' @return `NULL`. All test files are executed and errors are collected; if any
-#'   tests fail, a single error is thrown at the end with all failure messages
-#'   combined.
-#' @note The **testit** package must be loaded (e.g., via `library(testit)`)
-#'   before calling `test_pkg()`, because test scripts typically call
-#'   [assert()] and other **testit** functions directly without the `testit::`
-#'   prefix. Simply using `testit::test_pkg()` without loading the package first
-#'   will result in errors like "could not find function \"assert\"".
+#'   files. Only files whose names match the pattern will be run. For example,
+#'   `filter = "parse"` runs only test files with "parse" in their names.
+#' @param update Controls snapshot file behavior:
+#'   - `TRUE`: always update snapshot files with actual output (never errors).
+#'   - `NA` (default): update only if the file is tracked by Git (so you can
+#'     review diffs before accepting).
+#'   - `FALSE`: never update; always compare and error on mismatch.
+#' @return Invisible `NULL`. If any tests fail, a single error is thrown at the
+#'   end with all failure messages combined.
+#' @note You must call `library(testit)` before `test_pkg()`. Test scripts use
+#'   [assert()] and other **testit** functions without the `testit::` prefix, so
+#'   the package needs to be on the search path. Without `library(testit)`, you
+#'   will get "could not find function" errors.
 #'
-#' All test scripts must be encoded in UTF-8 if they contain any multibyte
+#'   All test scripts must be encoded in UTF-8 if they contain multibyte
 #'   characters.
 #' @export
 #' @examples
@@ -310,21 +299,21 @@ error_loc = function(x, line = 1) {
   sprintf(' at \033]8;line = %d:col = 1;file://%s\a%s#%d\033]8;;\a', line, full, rel, line)
 }
 
-#' Check if an R expression produces messages, warnings, or errors
+#' Test whether an expression signals a condition
 #'
-#' The functions `has_message()`, `has_warning()`, and `has_error()` check if an
-#' expression produces messages, warnings, and errors, respectively. When the
-#' `message` argument is provided, the condition message is matched against it
-#' via [grepl()].
-#' @param expr an R expression
-#' @param message optionally, a string (fixed or regex pattern) to match against
-#'   the condition message. If provided, the function returns `TRUE` only when
-#'   the condition is signaled *and* the message matches.
-#' @param ... additional arguments passed to [grepl()] for matching `message`
-#'   against the condition message (e.g., `fixed = TRUE` for fixed string
-#'   matching, or `ignore.case = TRUE`). Note that `fixed = TRUE` is the
-#'   default.
-#' @return A logical value.
+#' Check if evaluating an expression produces a message, warning, or error.
+#' These functions are designed to be used inside [assert()] to verify that code
+#' signals the expected conditions. Optionally, you can match against the
+#' condition's text to ensure the *right* message/warning/error was signaled.
+#' @param expr An R expression to evaluate.
+#' @param message An optional string to match against the condition text. Uses
+#'   fixed (literal) matching by default. If provided, the function returns
+#'   `TRUE` only when the condition is signaled *and* the message matches.
+#' @param ... Additional arguments passed to [grepl()] for matching (e.g.,
+#'   `fixed = FALSE` to use regex, or `ignore.case = TRUE`). Note that
+#'   `fixed = TRUE` is the default.
+#' @return `TRUE` if the condition was signaled (and the message matched, if
+#'   provided), `FALSE` otherwise.
 #' @export
 #' @rdname has_message
 #' @examples
@@ -374,7 +363,10 @@ match_cond = function(text, message, ...) {
     grepl2(message, text, ...)
 }
 
-grepl2 = function(..., fixed = TRUE) grepl(..., fixed = fixed)
+grepl2 = function(..., fixed = TRUE, ignore.case = FALSE) {
+  if (ignore.case && fixed) fixed = FALSE
+  grepl(..., fixed = fixed, ignore.case = ignore.case)
+}
 
 quietly = function(expr) {
   withCallingHandlers(

--- a/R/testit.R
+++ b/R/testit.R
@@ -1,35 +1,34 @@
 #' Assertions with an optional message
 #'
-#' The function \code{assert()} was inspired by \code{\link{stopifnot}()}. It
-#' emits a message in case of errors, which can be a helpful hint for diagnosing
-#' the errors (\code{stopifnot()} only prints the possibly truncated source code
-#' of the expressions).
+#' The function `assert()` was inspired by [stopifnot()]. It emits a message in
+#' case of errors, which can be a helpful hint for diagnosing the errors
+#' (`stopifnot()` only prints the possibly truncated source code of the
+#' expressions).
 #'
-#' For the \code{...} argument, it should be a single R expression wrapped in
-#' \code{{}}. This expression may contain multiple sub-expressions. A
-#' sub-expression is treated as a test condition if it is wrapped in \code{()}
-#' (meaning its value will be checked to see if it is a logical vector
-#' containing any \code{FALSE} values) , otherwise it is evaluated in the normal
-#' way and its value will not be checked. If the value of the last
-#' sub-expression is logical, it will also be treated as a test condition.
+#' For the `...` argument, it should be a single R expression wrapped in `{}`.
+#' This expression may contain multiple sub-expressions. A sub-expression is
+#' treated as a test condition if it is wrapped in `()` (meaning its value will
+#' be checked to see if it is a logical vector containing any `FALSE` values) ,
+#' otherwise it is evaluated in the normal way and its value will not be
+#' checked. If the value of the last sub-expression is logical, it will also be
+#' treated as a test condition.
 #' @param fact A message for the assertions when any of them fails; treated the
-#'   same way as expressions in \code{...} if it is not a character string,
-#'   which means you are not required to provide a message to this function.
+#'   same way as expressions in `...` if it is not a character string, which
+#'   means you are not required to provide a message to this function.
 #' @param ... An R expression; see Details.
-#' @return For \code{assert()}, invisible \code{NULL} if all expressions
-#'   returned \code{TRUE}, otherwise an error is signaled and the user-provided
-#'   message is emitted. For \code{\%==\%}, \code{TRUE} or \code{FALSE}.
-#' @note The internal implementation of \code{assert()} is different with the
-#'   \code{stopifnot()} function in R \pkg{base}: (1) the custom message
-#'   \code{fact} is emitted if an error occurs; (2) \code{assert()} requires the
-#'   logical values to be non-empty (\code{logical(0)} will trigger an error);
-#'   (3) if \code{...} contains a compound expression in \code{{}} that returns
-#'   \code{FALSE} (e.g., \code{if (TRUE) {1+1; FALSE}}), the first and the last
-#'   but one line of the source code from \code{\link{deparse}()} are printed in
-#'   the error message, otherwise the first line is printed; (4) the arguments
-#'   in \code{...} are evaluated sequentially, and \code{assert()} will signal
-#'   an error upon the first failed assertion, and will ignore the rest of
-#'   assertions.
+#' @return For `assert()`, invisible `NULL` if all expressions returned `TRUE`,
+#'   otherwise an error is signaled and the user-provided message is emitted.
+#'   For `%==%`, `TRUE` or `FALSE`.
+#' @note The internal implementation of `assert()` is different with the
+#'   `stopifnot()` function in R **base**: (1) the custom message `fact` is
+#'   emitted if an error occurs; (2) `assert()` requires the logical values to
+#'   be non-empty (`logical(0)` will trigger an error); (3) if `...` contains a
+#'   compound expression in `{}` that returns `FALSE` (e.g., `if (TRUE) {1+1;
+#'   FALSE}`), the first and the last but one line of the source code from
+#'   [deparse()] are printed in the error message, otherwise the first line is
+#'   printed; (4) the arguments in `...` are evaluated sequentially, and
+#'   `assert()` will signal an error upon the first failed assertion, and will
+#'   ignore the rest of assertions.
 #' @export
 #' @examples
 #' library(testit)
@@ -114,13 +113,12 @@ assert2 = function(fact, exprs, envir, all = TRUE, loc = NULL) {
   if (length(errs)) stop(paste(errs, collapse = '\n'), call. = FALSE, domain = NA)
 }
 
-#' @description The infix operator \code{\%==\%} is simply an alias of the
-#'   \code{\link{identical}()} function to make it slightly easier and intuitive
-#'   to write test conditions. \code{x \%==\% y} is the same as
-#'   \code{identical(x, y)}. When it is used inside \code{assert()}, a message
-#'   will be printed if the returned value is not \code{TRUE}, to show the
-#'   values of the LHS (\code{x}) and RHS (\code{y}) via \code{\link{str}()},
-#'   which can be helpful for you to check why the assertion failed.
+#' @description The infix operator `%==%` is simply an alias of the
+#'   [identical()] function to make it slightly easier and intuitive to write
+#'   test conditions. `x %==% y` is the same as `identical(x, y)`. When it is
+#'   used inside `assert()`, a message will be printed if the returned value is
+#'   not `TRUE`, to show the values of the LHS (`x`) and RHS (`y`) via
+#'   [str()], which can be helpful for you to check why the assertion failed.
 #' @param x,y two R objects to be compared
 #' @rdname assert
 #' @import utils
@@ -151,57 +149,55 @@ assert2 = function(fact, exprs, envir, all = TRUE, loc = NULL) {
 #' The tests are executed in a clean environment with the namespace of the
 #' package to be tested as the parent environment, which means you can use
 #' non-exported objects in the package without having to resort to the triple
-#' colon \code{\link{:::}} trick.
+#' colon `:::` trick.
 #'
-#' The tests are assumed to be under the \file{testit/} or \file{tests/testit/}
-#' directory by default (depending on your working directory is the package root
-#' directory or the \file{tests/} directory). The test scripts must be named of
-#' the form \samp{test-*.R} (or \samp{test-*.md} for snapshot tests); other
-#' files will not be treated as test files (but may also be useful, e.g. you can
-#' \code{\link{source}()} other scripts in tests).
+#' The tests are assumed to be under the `testit/` or `tests/testit/` directory
+#' by default (depending on your working directory is the package root directory
+#' or the `tests/` directory). The test scripts must be named of the form
+#' `test-*.R` (or `test-*.md` for snapshot tests); other files will not be
+#' treated as test files (but may also be useful, e.g. you can [source()] other
+#' scripts in tests).
 #'
-#' Helper files named \samp{helper*.R} (e.g., \samp{helper.R},
-#' \samp{helper-utils.R}) are sourced before test files and remain available
-#' to all tests, allowing you to define shared utility functions.
+#' Helper files named `helper*.R` (e.g., `helper.R`, `helper-utils.R`) are
+#' sourced before test files and remain available to all tests, allowing you to
+#' define shared utility functions.
 #'
 #' When a test is executed, the working directory is the same as the directory
 #' containing this test, and all existing objects in the test environment will
 #' be removed before the code is executed (except for helper functions).
 #'
-#' See \url{https://pkg.yihui.org/testit/#snapshot-testing} for more details
-#' about snapshot testing.
+#' See <https://pkg.yihui.org/testit/#snapshot-testing> for more details about
+#' snapshot testing.
 #' @param package The package name. By default, it is detected from the
-#'   \file{DESCRIPTION} file if exists.
-#' @param dir The directory of the test files. If \code{NULL} (the default), the
-#'   directory \file{testit/} or \file{tests/testit/} under the current working
-#'   directory is used (whichever exists). You can also specify a custom
-#'   directory.
+#'   `DESCRIPTION` file if exists.
+#' @param dir The directory of the test files. If `NULL` (the default), the
+#'   directory `testit/` or `tests/testit/` under the current working directory
+#'   is used (whichever exists). You can also specify a custom directory.
 #' @param filter An optional regular expression to select a subset of test
 #'   files. Only files whose names (without directory) match the pattern will be
-#'   run. For example, \code{filter = "parse"} runs only test files with
-#'   \dQuote{parse} in their names.
-#' @param update If \code{TRUE}, update snapshot files with actual output
-#'   instead of comparing. If \code{NA} (the default), update snapshot files
-#'   only if they are tracked by GIT (so you can view the diffs in GIT and
-#'   decide whether to accept or discard the changes). If \code{FALSE}, never
-#'   update snapshot files and always compare. For \code{NA} and \code{FALSE},
-#'   if the snapshot test fails, it will throw an error with a message showing
-#'   the location of the failed test. For \code{TRUE}, it will update the
-#'   snapshot file and never throw an error.
-#' @return \code{NULL}. All test files are executed and errors are collected; if
-#'   any tests fail, a single error is thrown at the end with all failure
-#'   messages combined.
-#' @note The \pkg{testit} package must be loaded (e.g., via
-#'   \code{library(testit)}) before calling \code{test_pkg()}, because test
-#'   scripts typically call \code{\link{assert}()} and other \pkg{testit}
-#'   functions directly without the \code{testit::} prefix. Simply using
-#'   \code{testit::test_pkg()} without loading the package first will result in
-#'   errors like \dQuote{could not find function "assert"}.
+#'   run. For example, `filter = "parse"` runs only test files with "parse" in
+#'   their names.
+#' @param update If `TRUE`, update snapshot files with actual output instead of
+#'   comparing. If `NA` (the default), update snapshot files only if they are
+#'   tracked by GIT (so you can view the diffs in GIT and decide whether to
+#'   accept or discard the changes). If `FALSE`, never update snapshot files and
+#'   always compare. For `NA` and `FALSE`, if the snapshot test fails, it will
+#'   throw an error with a message showing the location of the failed test. For
+#'   `TRUE`, it will update the snapshot file and never throw an error.
+#' @return `NULL`. All test files are executed and errors are collected; if any
+#'   tests fail, a single error is thrown at the end with all failure messages
+#'   combined.
+#' @note The **testit** package must be loaded (e.g., via `library(testit)`)
+#'   before calling `test_pkg()`, because test scripts typically call
+#'   [assert()] and other **testit** functions directly without the `testit::`
+#'   prefix. Simply using `testit::test_pkg()` without loading the package first
+#'   will result in errors like "could not find function \"assert\"".
 #'
 #' All test scripts must be encoded in UTF-8 if they contain any multibyte
 #'   characters.
 #' @export
-#' @examples \dontrun{
+#' @examples
+#' \dontrun{
 #' library(testit)
 #' test_pkg('testit')
 #' }
@@ -316,18 +312,18 @@ error_loc = function(x, line = 1) {
 
 #' Check if an R expression produces messages, warnings, or errors
 #'
-#' The functions \code{has_message()}, \code{has_warning()}, and
-#' \code{has_error()} check if an expression produces messages, warnings, and
-#' errors, respectively. When the \code{message} argument is provided, the
-#' condition message is matched against it via \code{\link{grepl}()}.
+#' The functions `has_message()`, `has_warning()`, and `has_error()` check if an
+#' expression produces messages, warnings, and errors, respectively. When the
+#' `message` argument is provided, the condition message is matched against it
+#' via [grepl()].
 #' @param expr an R expression
 #' @param message optionally, a string (fixed or regex pattern) to match against
-#'   the condition message. If provided, the function returns \code{TRUE} only
-#'   when the condition is signaled \emph{and} the message matches.
-#' @param ... additional arguments passed to \code{\link{grepl}()} for matching
-#'   \code{message} against the condition message (e.g., \code{fixed = TRUE} for
-#'   fixed string matching, or \code{ignore.case = TRUE}). Note that \code{fixed
-#'   = TRUE} is the default.
+#'   the condition message. If provided, the function returns `TRUE` only when
+#'   the condition is signaled *and* the message matches.
+#' @param ... additional arguments passed to [grepl()] for matching `message`
+#'   against the condition message (e.g., `fixed = TRUE` for fixed string
+#'   matching, or `ignore.case = TRUE`). Note that `fixed = TRUE` is the
+#'   default.
 #' @return A logical value.
 #' @export
 #' @rdname has_message

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ test_pkg('yourpkg')
 find function `assert`".
 
 That's all. `R CMD check` will run your tests automatically. In RStudio, you can
-also press `Ctrl/Cmd + Shift + T` to run tests during development.
+also press `Ctrl/Cmd + Shift + T` to run tests during development. For this to
+work, go to `Build > Configure Build Tools...` and make sure "Use devtools
+package functions if available" is **unchecked** (otherwise RStudio will try to
+use **testthat** conventions instead).
 
 ### Helper files
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ assert('basic arithmetic works', {
 To test if two objects are identical, use `%==%` (a shortcut for `identical()`).
 When a `%==%` comparison fails inside `assert()`, you get a helpful diff showing
 what was different:
+
 ``` r
 assert('identical comparison', {
   (c(1, 2, 3) %==% 1:3)
@@ -115,9 +116,9 @@ Place files named `test-*.md` in your `tests/testit/` directory:
 ```
 ````
 
-The R code block (` ```r `) is executed and its output is compared to the
-following plain code block (` ``` `). If the output changes, the test fails with
-a diff. To accept the new output, run:
+The R code block (```` ```r ````) is executed and its output is compared to the
+following plain code block (```` ``` ````). If the output changes, the test
+fails with a diff. To accept the new output, run:
 
 ``` r
 test_pkg(update = TRUE)
@@ -128,12 +129,12 @@ evaluated.
 
 ## Setting up tests in your package
 
-1. Create the directory `tests/testit/` in your package.
+1.  Create the directory `tests/testit/` in your package.
 
-2. Write test files named `test-*.R` (and optionally `test-*.md` for
-   snapshots).
+2.  Write test files named `test-*.R` (and optionally `test-*.md` for
+    snapshots).
 
-3. Create `tests/test-all.R` with:
+3.  Create `tests/test-all.R` with:
 
 ``` r
 library(testit)
@@ -146,9 +147,9 @@ find function `assert`".
 
 That's all. `R CMD check` will run your tests automatically. In RStudio, you can
 also press `Ctrl/Cmd + Shift + T` to run tests during development. For this to
-work, go to `Build > Configure Build Tools...` and make sure "Use devtools
-package functions if available" is **unchecked** (otherwise RStudio will try to
-use **testthat** conventions instead).
+work, go to the menu `Build > Configure Build Tools...` and make sure "Use
+devtools package functions if available" is **unchecked** (otherwise RStudio
+will try to use **testthat** conventions instead).
 
 ### Helper files
 
@@ -167,11 +168,11 @@ non-exported (internal) functions directly -- no need for the `:::` operator.
 around an expression means "this must be `TRUE`." There are no matchers like
 `expect_equal` vs. `expect_identical` vs. `expect_equivalent` to choose between.
 
-The tradeoff is that you get fewer bells and whistles (no mocking, no test
-reporters, no parallel execution). If you want a simple, dependency-free testing
-tool that stays out of your way, **testit** is a good fit.
+The tradeoff is that you get fewer bells and whistles (no mocking, no parallel
+execution). If you want a simple, dependency-free testing tool that stays out of
+your way, **testit** is a good fit.
 
----
+--------------------------------------------------------------------------------
 
 <img src="https://i.imgur.com/sDsgmfj.jpeg" alt="Xunzi" align="right" width="100"/>
 

--- a/README.md
+++ b/README.md
@@ -10,110 +10,12 @@ coverage](https://codecov.io/gh/yihui/testit/graph/badge.svg)](https://app.codec
 
 <!-- badges: end -->
 
-This package provides two simple functions:
-
-- `assert(fact, ...)`: think of it as `message(fact)` + `stopifnot(...)`
-
-- `test_pkg(package)`: runs tests with all objects (exported or non-exported) in
-  the package namespace directly available, so no need to use the triple-colon
-  `package:::name` for non-exported objects
-
-Snapshot testing is also supported via markdown files (`test-*.md`) in the same
-test directory.
-
-## Why?
-
-Because it is tedious to type these commands repeatedly in tests:
-
-``` r
-message('checking if these numbers are equal...')
-stopifnot(all.equal(1, 1+1e-10), 10*.1 == 1)
-
-message('checking if a non-exported function works...')
-stopifnot(is.character(package:::utility_foo(x = 'abcd', y = 1:100)))
-```
-
-With the two simple functions above, we type six letters (`assert`) instead of
-sixteen (`message` + `stopifnot`), and `assert` is also a more intuitive
-function name for testing purposes (you *assert* a fact followed by evidence):
-
-``` r
-assert('These numbers are equal', {
-
-  (all.equal(1, 1 + 1e-10))
-
-  (10 * .1 == 1)
-
-})
-
-assert('A non-exported function works', {
-  res = utility_foo(x = 'abcd', y = 1:100)
-  (is.character(res))
-})
-
-assert('T is TRUE and F is FALSE by default, but can be changed', {
-  (T == TRUE )
-  (F == FALSE)
-
-  T = FALSE
-  (T == FALSE)
-})
-```
-
-## Snapshot testing
-
-Snapshot tests use Markdown files that combine R code with expected output.
-Place `.md` files named `test-*.md` in the `tests/testit/` directory, and they
-will be automatically run by `test_pkg()`.
-
-Each Markdown file contains R code blocks followed by expected output blocks:
-
-```` markdown
-# Test description
-
-```r
-1:5
-```
-
-```
-[1] 1 2 3 4 5
-```
-````
-
-The R code blocks are marked with ```` ```r ```` (or ```` ```{r} ````) and
-output blocks with ```` ``` ````. When tests run, the R code is executed and
-output is compared to the expected output block. If a markdown file doesn't have
-output blocks initially, they will be added automatically. To update snapshots
-when output changes, run `testit::test_pkg(update = TRUE)`.
-
-Snapshot files are human-readable Markdown, making them easy to review in
-version control. Optionally, you can write ordinary text anywhere in the file,
-e.g., to explain the test or provide additional context. Snapshot testing will
-only compare the output of R code blocks to the expected output blocks, ignoring
-any other text.
-
-## R CMD check
-
-Put the tests under the directory `pkg_name/tests/testit/` (where `pkg_name` is
-the root directory of your package), and write a `test-all.R` under
-`pkg_name/tests/`:
-
-``` r
-library(testit)
-test_pkg('pkg_name')
-```
-
-Note that `library(testit)` is required here because test scripts call
-`assert()` and other **testit** functions directly (without the `testit::`
-prefix). Using `testit::test_pkg()` alone without loading the package first will
-result in errors like "could not find function `assert`".
-
-That is all for `R CMD check`. For package development, you can
-`Ctrl/Cmd + Shift + T` to run tests.
+**testit** is a minimal testing package for R with zero dependencies. If you can
+write an R expression that returns `TRUE`, you can write a test with **testit**.
 
 ## Installation
 
-Stable version on CRAN:
+From CRAN:
 
 ``` r
 install.packages('testit')
@@ -125,18 +27,148 @@ Development version:
 install.packages('testit', repos = 'https://yihui.r-universe.dev')
 ```
 
-## More
+## Quick start
 
-How about [**testthat**](https://CRAN.R-project.org/package=testthat)? Well,
-this package is far less sophisticated than **testthat**. There is nothing fancy
-in this package. I do not use **testthat** by myself because I'm too lazy to
-learn the new vocabulary (`testthat::expect_xxx`). For **testit**, I do not need
-to think if I should use `expect_equal`, `expect_equivalent`, or
-`expect_identical`; I just write test conditions in parentheses that are
-expected to return `TRUE`. That is the one and only rule to remember.
+The core idea: wrap conditions in parentheses `()` inside `assert()`. If the
+condition is `TRUE`, the test passes silently. If it is `FALSE`, you get an
+error with the message you provided.
 
-There is no plan to add new features or reinvent anything in this package. It is
-an intentionally tiny package with zero dependencies.
+``` r
+library(testit)
+
+assert('one plus one is two', {
+  (1 + 1 == 2)
+})
+```
+
+You can put multiple conditions in one `assert()` call, and mix in setup code
+(lines without parentheses are just evaluated normally):
+
+``` r
+assert('basic arithmetic works', {
+  x = 1 + 1
+  (x == 2)
+  (x > 0)
+})
+```
+
+To test if two objects are identical, use `%==%` (a shortcut for `identical()`).
+When a `%==%` comparison fails inside `assert()`, you get a helpful diff showing
+what was different:
+``` r
+assert('identical comparison', {
+  (c(1, 2, 3) %==% 1:3)
+})
+```
+
+## How it works
+
+**testit** has one rule: an expression in parentheses `()` is a test condition
+that must evaluate to `TRUE`. Everything else is ordinary R code.
+
+``` r
+assert('a descriptive message about what you are testing', {
+  # setup code (no parentheses = not checked)
+  x = sqrt(4)
+
+  # test conditions (parentheses = must be TRUE)
+  (x == 2)
+  (x > 0)
+  (is.numeric(x))
+})
+```
+
+That's it. No special matchers to memorize, no DSL to learn.
+
+## Testing for errors, warnings, and messages
+
+Use `has_error()`, `has_warning()`, and `has_message()` to verify that code
+signals the expected condition:
+
+``` r
+assert('errors are caught correctly', {
+  (has_error(log('a')))
+  (has_error(stop('oops'), 'oops'))  # also match the error message
+  (!has_error(log(1)))               # no error here
+})
+
+assert('warnings are caught correctly', {
+  (has_warning(warning('watch out')))
+  (has_warning(1:2 + 1:3, 'longer object'))
+})
+```
+
+## Snapshot testing
+
+Snapshot tests let you verify printed output by recording it in a Markdown file.
+Place files named `test-*.md` in your `tests/testit/` directory:
+
+```` markdown
+# Printing a sequence
+
+```r
+1:5
+```
+
+```
+[1] 1 2 3 4 5
+```
+````
+
+The R code block (` ```r `) is executed and its output is compared to the
+following plain code block (` ``` `). If the output changes, the test fails with
+a diff. To accept the new output, run:
+
+``` r
+test_pkg(update = TRUE)
+```
+
+You can write explanatory text anywhere in the file -- only code blocks are
+evaluated.
+
+## Setting up tests in your package
+
+1. Create the directory `tests/testit/` in your package.
+
+2. Write test files named `test-*.R` (and optionally `test-*.md` for
+   snapshots).
+
+3. Create `tests/test-all.R` with:
+
+``` r
+library(testit)
+test_pkg('yourpkg')
+```
+
+`library(testit)` is required because test scripts call `assert()` and other
+**testit** functions directly. Without it, you will get errors like "could not
+find function `assert`".
+
+That's all. `R CMD check` will run your tests automatically. In RStudio, you can
+also press `Ctrl/Cmd + Shift + T` to run tests during development.
+
+### Helper files
+
+If you have shared setup code, put it in files named `helper*.R` (e.g.,
+`helper.R`, `helper-utils.R`) in the same test directory. They are sourced
+before any test file runs.
+
+### Accessing internal functions
+
+`test_pkg()` runs your tests inside the package namespace, so you can call
+non-exported (internal) functions directly -- no need for the `:::` operator.
+
+## Comparison with testthat
+
+**testit** is intentionally minimal. There is one rule to remember: parentheses
+around an expression means "this must be `TRUE`." There are no matchers like
+`expect_equal` vs. `expect_identical` vs. `expect_equivalent` to choose between.
+
+The tradeoff is that you get fewer bells and whistles (no mocking, no test
+reporters, no parallel execution). If you want a simple, dependency-free testing
+tool that stays out of your way, **testit** is a good fit.
+
+---
 
 <img src="https://i.imgur.com/sDsgmfj.jpeg" alt="Xunzi" align="right" width="100"/>
 
@@ -144,5 +176,8 @@ Although he did not really mean it, [Xunzi](https://en.wikipedia.org/wiki/Xunzi)
 said something that happens to apply well to unit testing:
 
 > 不积跬步，无以至千里；不积小流，无以成江海。
+
+(A journey of a thousand miles begins with a single step; a great river is
+formed from many small streams.)
 
 This package is free and open source software, licensed under MIT.

--- a/man/assert.Rd
+++ b/man/assert.Rd
@@ -3,58 +3,56 @@
 \name{assert}
 \alias{assert}
 \alias{\%==\%}
-\title{Assertions with an optional message}
+\title{Assert that conditions are true, with an informative failure message}
 \usage{
 assert(fact, ...)
 
 x \%==\% y
 }
 \arguments{
-\item{fact}{A message for the assertions when any of them fails; treated the
-same way as expressions in \code{...} if it is not a character string, which
-means you are not required to provide a message to this function.}
+\item{fact}{A character string describing what is being tested. This message
+is shown when an assertion fails, so make it descriptive (e.g., \code{'log() returns correct values'}). If \code{fact} is not a character string, it is
+treated as a test expression (i.e., the message is optional).}
 
-\item{...}{An R expression; see Details.}
+\item{...}{An R expression wrapped in \code{{}}; see Details.}
 
-\item{x, y}{two R objects to be compared}
+\item{x, y}{Two R objects to be compared for identity.}
 }
 \value{
-For \code{assert()}, invisible \code{NULL} if all expressions returned \code{TRUE},
-otherwise an error is signaled and the user-provided message is emitted.
-For \verb{\%==\%}, \code{TRUE} or \code{FALSE}.
+Invisible \code{NULL} if all conditions pass. If any condition fails, an
+error is signaled that includes the \code{fact} message and the expression that
+failed. For \verb{\%==\%}, \code{TRUE} or \code{FALSE}.
 }
 \description{
-The function \code{assert()} was inspired by \code{\link[=stopifnot]{stopifnot()}}. It emits a message in
-case of errors, which can be a helpful hint for diagnosing the errors
-(\code{stopifnot()} only prints the possibly truncated source code of the
-expressions).
+Test that one or more conditions are \code{TRUE}. If any condition fails, an error
+is raised with the \code{fact} message, making it easy to identify which test
+failed and why. This is the primary function for writing tests with
+\strong{testit}.
 
-The infix operator \verb{\%==\%} is simply an alias of the
-\code{\link[=identical]{identical()}} function to make it slightly easier and intuitive to write
-test conditions. \code{x \%==\% y} is the same as \code{identical(x, y)}. When it is
-used inside \code{assert()}, a message will be printed if the returned value is
-not \code{TRUE}, to show the values of the LHS (\code{x}) and RHS (\code{y}) via
-\code{\link[=str]{str()}}, which can be helpful for you to check why the assertion failed.
+The infix operator \verb{\%==\%} is a shortcut for \code{\link[=identical]{identical()}} that
+provides helpful diagnostics on failure. \code{x \%==\% y} returns \code{TRUE} if \code{x}
+and \code{y} are identical, and \code{FALSE} otherwise. When used inside \code{assert()},
+a failing \verb{\%==\%} comparison will display both values via \code{\link[=str]{str()}} so you can
+see exactly what differed.
 }
 \details{
-For the \code{...} argument, it should be a single R expression wrapped in \code{{}}.
-This expression may contain multiple sub-expressions. A sub-expression is
-treated as a test condition if it is wrapped in \verb{()} (meaning its value will
-be checked to see if it is a logical vector containing any \code{FALSE} values) ,
-otherwise it is evaluated in the normal way and its value will not be
-checked. If the value of the last sub-expression is logical, it will also be
-treated as a test condition.
+The recommended usage is to pass a single expression wrapped in \code{{}} as the
+second argument. Inside \code{{}}, any sub-expression wrapped in parentheses \verb{()}
+is treated as a test condition -- its value is checked and must be \code{TRUE}.
+Sub-expressions \emph{without} parentheses are ordinary R code (e.g., variable
+assignments or setup steps) and their values are not checked. The last
+sub-expression is also treated as a test condition if it returns a logical
+value, even without explicit parentheses.
 }
 \note{
-The internal implementation of \code{assert()} is different with the
-\code{stopifnot()} function in R \strong{base}: (1) the custom message \code{fact} is
-emitted if an error occurs; (2) \code{assert()} requires the logical values to
-be non-empty (\code{logical(0)} will trigger an error); (3) if \code{...} contains a
-compound expression in \code{{}} that returns \code{FALSE} (e.g., \code{if (TRUE) {1+1; FALSE}}), the first and the last but one line of the source code from
-\code{\link[=deparse]{deparse()}} are printed in the error message, otherwise the first line is
-printed; (4) the arguments in \code{...} are evaluated sequentially, and
-\code{assert()} will signal an error upon the first failed assertion, and will
-ignore the rest of assertions.
+Key differences from \code{\link[=stopifnot]{stopifnot()}}:
+\itemize{
+\item \code{assert()} shows your custom \code{fact} message on failure, making errors
+easier to diagnose.
+\item \code{logical(0)} (empty logical) is treated as a failure, not a pass.
+\item Assertions are evaluated sequentially; \code{assert()} stops at the first
+failure and reports it.
+}
 }
 \examples{
 library(testit)

--- a/man/assert.Rd
+++ b/man/assert.Rd
@@ -50,8 +50,8 @@ Key differences from \code{\link[=stopifnot]{stopifnot()}}:
 \item \code{assert()} shows your custom \code{fact} message on failure, making errors
 easier to diagnose.
 \item \code{logical(0)} (empty logical) is treated as a failure, not a pass.
-\item Assertions are evaluated sequentially; \code{assert()} stops at the first
-failure and reports it.
+\item All conditions are evaluated even if earlier ones fail; all failures are
+reported together in a single error message.
 }
 }
 \examples{

--- a/man/assert.Rd
+++ b/man/assert.Rd
@@ -11,53 +11,50 @@ x \%==\% y
 }
 \arguments{
 \item{fact}{A message for the assertions when any of them fails; treated the
-same way as expressions in \code{...} if it is not a character string,
-which means you are not required to provide a message to this function.}
+same way as expressions in \code{...} if it is not a character string, which
+means you are not required to provide a message to this function.}
 
 \item{...}{An R expression; see Details.}
 
 \item{x, y}{two R objects to be compared}
 }
 \value{
-For \code{assert()}, invisible \code{NULL} if all expressions
-  returned \code{TRUE}, otherwise an error is signaled and the user-provided
-  message is emitted. For \code{\%==\%}, \code{TRUE} or \code{FALSE}.
+For \code{assert()}, invisible \code{NULL} if all expressions returned \code{TRUE},
+otherwise an error is signaled and the user-provided message is emitted.
+For \verb{\%==\%}, \code{TRUE} or \code{FALSE}.
 }
 \description{
-The function \code{assert()} was inspired by \code{\link{stopifnot}()}. It
-emits a message in case of errors, which can be a helpful hint for diagnosing
-the errors (\code{stopifnot()} only prints the possibly truncated source code
-of the expressions).
+The function \code{assert()} was inspired by \code{\link[=stopifnot]{stopifnot()}}. It emits a message in
+case of errors, which can be a helpful hint for diagnosing the errors
+(\code{stopifnot()} only prints the possibly truncated source code of the
+expressions).
 
-The infix operator \code{\%==\%} is simply an alias of the
-  \code{\link{identical}()} function to make it slightly easier and intuitive
-  to write test conditions. \code{x \%==\% y} is the same as
-  \code{identical(x, y)}. When it is used inside \code{assert()}, a message
-  will be printed if the returned value is not \code{TRUE}, to show the
-  values of the LHS (\code{x}) and RHS (\code{y}) via \code{\link{str}()},
-  which can be helpful for you to check why the assertion failed.
+The infix operator \verb{\%==\%} is simply an alias of the
+\code{\link[=identical]{identical()}} function to make it slightly easier and intuitive to write
+test conditions. \code{x \%==\% y} is the same as \code{identical(x, y)}. When it is
+used inside \code{assert()}, a message will be printed if the returned value is
+not \code{TRUE}, to show the values of the LHS (\code{x}) and RHS (\code{y}) via
+\code{\link[=str]{str()}}, which can be helpful for you to check why the assertion failed.
 }
 \details{
-For the \code{...} argument, it should be a single R expression wrapped in
-\code{{}}. This expression may contain multiple sub-expressions. A
-sub-expression is treated as a test condition if it is wrapped in \code{()}
-(meaning its value will be checked to see if it is a logical vector
-containing any \code{FALSE} values) , otherwise it is evaluated in the normal
-way and its value will not be checked. If the value of the last
-sub-expression is logical, it will also be treated as a test condition.
+For the \code{...} argument, it should be a single R expression wrapped in \code{{}}.
+This expression may contain multiple sub-expressions. A sub-expression is
+treated as a test condition if it is wrapped in \verb{()} (meaning its value will
+be checked to see if it is a logical vector containing any \code{FALSE} values) ,
+otherwise it is evaluated in the normal way and its value will not be
+checked. If the value of the last sub-expression is logical, it will also be
+treated as a test condition.
 }
 \note{
 The internal implementation of \code{assert()} is different with the
-  \code{stopifnot()} function in R \pkg{base}: (1) the custom message
-  \code{fact} is emitted if an error occurs; (2) \code{assert()} requires the
-  logical values to be non-empty (\code{logical(0)} will trigger an error);
-  (3) if \code{...} contains a compound expression in \code{{}} that returns
-  \code{FALSE} (e.g., \code{if (TRUE) {1+1; FALSE}}), the first and the last
-  but one line of the source code from \code{\link{deparse}()} are printed in
-  the error message, otherwise the first line is printed; (4) the arguments
-  in \code{...} are evaluated sequentially, and \code{assert()} will signal
-  an error upon the first failed assertion, and will ignore the rest of
-  assertions.
+\code{stopifnot()} function in R \strong{base}: (1) the custom message \code{fact} is
+emitted if an error occurs; (2) \code{assert()} requires the logical values to
+be non-empty (\code{logical(0)} will trigger an error); (3) if \code{...} contains a
+compound expression in \code{{}} that returns \code{FALSE} (e.g., \code{if (TRUE) {1+1; FALSE}}), the first and the last but one line of the source code from
+\code{\link[=deparse]{deparse()}} are printed in the error message, otherwise the first line is
+printed; (4) the arguments in \code{...} are evaluated sequentially, and
+\code{assert()} will signal an error upon the first failed assertion, and will
+ignore the rest of assertions.
 }
 \examples{
 library(testit)

--- a/man/has_message.Rd
+++ b/man/has_message.Rd
@@ -16,22 +16,22 @@ has_error(expr, message = NULL, ...)
 \item{expr}{an R expression}
 
 \item{message}{optionally, a string (fixed or regex pattern) to match against
-the condition message. If provided, the function returns \code{TRUE} only
-when the condition is signaled \emph{and} the message matches.}
+the condition message. If provided, the function returns \code{TRUE} only when
+the condition is signaled \emph{and} the message matches.}
 
-\item{...}{additional arguments passed to \code{\link{grepl}()} for matching
-\code{message} against the condition message (e.g., \code{fixed = TRUE} for
-fixed string matching, or \code{ignore.case = TRUE}). Note that \code{fixed
-= TRUE} is the default.}
+\item{...}{additional arguments passed to \code{\link[=grepl]{grepl()}} for matching \code{message}
+against the condition message (e.g., \code{fixed = TRUE} for fixed string
+matching, or \code{ignore.case = TRUE}). Note that \code{fixed = TRUE} is the
+default.}
 }
 \value{
 A logical value.
 }
 \description{
-The functions \code{has_message()}, \code{has_warning()}, and
-\code{has_error()} check if an expression produces messages, warnings, and
-errors, respectively. When the \code{message} argument is provided, the
-condition message is matched against it via \code{\link{grepl}()}.
+The functions \code{has_message()}, \code{has_warning()}, and \code{has_error()} check if an
+expression produces messages, warnings, and errors, respectively. When the
+\code{message} argument is provided, the condition message is matched against it
+via \code{\link[=grepl]{grepl()}}.
 }
 \examples{
 has_message(message('hello'))

--- a/man/has_message.Rd
+++ b/man/has_message.Rd
@@ -4,7 +4,7 @@
 \alias{has_message}
 \alias{has_warning}
 \alias{has_error}
-\title{Check if an R expression produces messages, warnings, or errors}
+\title{Test whether an expression signals a condition}
 \usage{
 has_message(expr, message = NULL, ...)
 
@@ -13,25 +13,25 @@ has_warning(expr, message = NULL, ...)
 has_error(expr, message = NULL, ...)
 }
 \arguments{
-\item{expr}{an R expression}
+\item{expr}{An R expression to evaluate.}
 
-\item{message}{optionally, a string (fixed or regex pattern) to match against
-the condition message. If provided, the function returns \code{TRUE} only when
-the condition is signaled \emph{and} the message matches.}
+\item{message}{An optional string to match against the condition text. Uses
+fixed (literal) matching by default. If provided, the function returns
+\code{TRUE} only when the condition is signaled \emph{and} the message matches.}
 
-\item{...}{additional arguments passed to \code{\link[=grepl]{grepl()}} for matching \code{message}
-against the condition message (e.g., \code{fixed = TRUE} for fixed string
-matching, or \code{ignore.case = TRUE}). Note that \code{fixed = TRUE} is the
-default.}
+\item{...}{Additional arguments passed to \code{\link[=grepl]{grepl()}} for matching (e.g.,
+\code{fixed = FALSE} to use regex, or \code{ignore.case = TRUE}). Note that
+\code{fixed = TRUE} is the default.}
 }
 \value{
-A logical value.
+\code{TRUE} if the condition was signaled (and the message matched, if
+provided), \code{FALSE} otherwise.
 }
 \description{
-The functions \code{has_message()}, \code{has_warning()}, and \code{has_error()} check if an
-expression produces messages, warnings, and errors, respectively. When the
-\code{message} argument is provided, the condition message is matched against it
-via \code{\link[=grepl]{grepl()}}.
+Check if evaluating an expression produces a message, warning, or error.
+These functions are designed to be used inside \code{\link[=assert]{assert()}} to verify that code
+signals the expected conditions. Optionally, you can match against the
+condition's text to ensure the \emph{right} message/warning/error was signaled.
 }
 \examples{
 has_message(message('hello'))

--- a/man/has_message.Rd
+++ b/man/has_message.Rd
@@ -21,7 +21,8 @@ when the condition is signaled \emph{and} the message matches.}
 
 \item{...}{additional arguments passed to \code{\link{grepl}()} for matching
 \code{message} against the condition message (e.g., \code{fixed = TRUE} for
-fixed string matching, or \code{ignore.case = TRUE}).}
+fixed string matching, or \code{ignore.case = TRUE}). Note that \code{fixed
+= TRUE} is the default.}
 }
 \value{
 A logical value.

--- a/man/test_pkg.Rd
+++ b/man/test_pkg.Rd
@@ -2,69 +2,63 @@
 % Please edit documentation in R/testit.R
 \name{test_pkg}
 \alias{test_pkg}
-\title{Run the tests of a package in its namespace}
+\title{Run all tests for a package}
 \usage{
 test_pkg(package = pkg_name(), dir = NULL, filter = NULL, update = NA)
 }
 \arguments{
 \item{package}{The package name. By default, it is detected from the
-\code{DESCRIPTION} file if exists.}
+\code{DESCRIPTION} file.}
 
-\item{dir}{The directory of the test files. If \code{NULL} (the default), the
-directory \verb{testit/} or \verb{tests/testit/} under the current working directory
-is used (whichever exists). You can also specify a custom directory.}
+\item{dir}{The directory containing test files. If \code{NULL} (the default),
+\verb{testit/} or \verb{tests/testit/} under the current working directory is used
+(whichever exists). You can also pass a custom path.}
 
 \item{filter}{An optional regular expression to select a subset of test
-files. Only files whose names (without directory) match the pattern will be
-run. For example, \code{filter = "parse"} runs only test files with "parse" in
-their names.}
+files. Only files whose names match the pattern will be run. For example,
+\code{filter = "parse"} runs only test files with "parse" in their names.}
 
-\item{update}{If \code{TRUE}, update snapshot files with actual output instead of
-comparing. If \code{NA} (the default), update snapshot files only if they are
-tracked by GIT (so you can view the diffs in GIT and decide whether to
-accept or discard the changes). If \code{FALSE}, never update snapshot files and
-always compare. For \code{NA} and \code{FALSE}, if the snapshot test fails, it will
-throw an error with a message showing the location of the failed test. For
-\code{TRUE}, it will update the snapshot file and never throw an error.}
+\item{update}{Controls snapshot file behavior:
+\itemize{
+\item \code{TRUE}: always update snapshot files with actual output (never errors).
+\item \code{NA} (default): update only if the file is tracked by Git (so you can
+review diffs before accepting).
+\item \code{FALSE}: never update; always compare and error on mismatch.
+}}
 }
 \value{
-\code{NULL}. All test files are executed and errors are collected; if any
-tests fail, a single error is thrown at the end with all failure messages
-combined.
+Invisible \code{NULL}. If any tests fail, a single error is thrown at the
+end with all failure messages combined.
 }
 \description{
-The tests are executed in a clean environment with the namespace of the
-package to be tested as the parent environment, which means you can use
-non-exported objects in the package without having to resort to the triple
-colon \code{:::} trick.
+Discover and execute test files (\verb{test-*.R} and \verb{test-*.md}) for a package.
+Tests are run inside the package namespace, so you can call internal
+(non-exported) functions directly without the \code{:::} operator.
 }
 \details{
-The tests are assumed to be under the \verb{testit/} or \verb{tests/testit/} directory
-by default (depending on your working directory is the package root directory
-or the \verb{tests/} directory). The test scripts must be named of the form
-\verb{test-*.R} (or \verb{test-*.md} for snapshot tests); other files will not be
-treated as test files (but may also be useful, e.g. you can \code{\link[=source]{source()}} other
-scripts in tests).
+Test files are looked up in the \verb{testit/} or \verb{tests/testit/} directory by
+default. Files must be named \verb{test-*.R} for regular tests or \verb{test-*.md} for
+snapshot tests. Other files in the directory are ignored (but you can
+\code{\link[=source]{source()}} them from your tests if needed).
 
 Helper files named \code{helper*.R} (e.g., \code{helper.R}, \code{helper-utils.R}) are
-sourced before test files and remain available to all tests, allowing you to
-define shared utility functions.
+sourced before any test file runs. Objects defined in helpers are available
+to all tests.
 
-When a test is executed, the working directory is the same as the directory
-containing this test, and all existing objects in the test environment will
-be removed before the code is executed (except for helper functions).
+Each test file runs in a clean environment (previous test objects are
+removed), and the working directory is set to the directory containing the
+test file.
 
 See \url{https://pkg.yihui.org/testit/#snapshot-testing} for more details about
 snapshot testing.
 }
 \note{
-The \strong{testit} package must be loaded (e.g., via \code{library(testit)})
-before calling \code{test_pkg()}, because test scripts typically call
-\code{\link[=assert]{assert()}} and other \strong{testit} functions directly without the \verb{testit::}
-prefix. Simply using \code{testit::test_pkg()} without loading the package first
-will result in errors like "could not find function \"assert\"".
+You must call \code{library(testit)} before \code{test_pkg()}. Test scripts use
+\code{\link[=assert]{assert()}} and other \strong{testit} functions without the \verb{testit::} prefix, so
+the package needs to be on the search path. Without \code{library(testit)}, you
+will get "could not find function" errors.
 
-All test scripts must be encoded in UTF-8 if they contain any multibyte
+All test scripts must be encoded in UTF-8 if they contain multibyte
 characters.
 }
 \examples{

--- a/man/test_pkg.Rd
+++ b/man/test_pkg.Rd
@@ -8,67 +8,64 @@ test_pkg(package = pkg_name(), dir = NULL, filter = NULL, update = NA)
 }
 \arguments{
 \item{package}{The package name. By default, it is detected from the
-\file{DESCRIPTION} file if exists.}
+\code{DESCRIPTION} file if exists.}
 
 \item{dir}{The directory of the test files. If \code{NULL} (the default), the
-directory \file{testit/} or \file{tests/testit/} under the current working
-directory is used (whichever exists). You can also specify a custom
-directory.}
+directory \verb{testit/} or \verb{tests/testit/} under the current working directory
+is used (whichever exists). You can also specify a custom directory.}
 
 \item{filter}{An optional regular expression to select a subset of test
 files. Only files whose names (without directory) match the pattern will be
-run. For example, \code{filter = "parse"} runs only test files with
-\dQuote{parse} in their names.}
+run. For example, \code{filter = "parse"} runs only test files with "parse" in
+their names.}
 
-\item{update}{If \code{TRUE}, update snapshot files with actual output
-instead of comparing. If \code{NA} (the default), update snapshot files
-only if they are tracked by GIT (so you can view the diffs in GIT and
-decide whether to accept or discard the changes). If \code{FALSE}, never
-update snapshot files and always compare. For \code{NA} and \code{FALSE},
-if the snapshot test fails, it will throw an error with a message showing
-the location of the failed test. For \code{TRUE}, it will update the
-snapshot file and never throw an error.}
+\item{update}{If \code{TRUE}, update snapshot files with actual output instead of
+comparing. If \code{NA} (the default), update snapshot files only if they are
+tracked by GIT (so you can view the diffs in GIT and decide whether to
+accept or discard the changes). If \code{FALSE}, never update snapshot files and
+always compare. For \code{NA} and \code{FALSE}, if the snapshot test fails, it will
+throw an error with a message showing the location of the failed test. For
+\code{TRUE}, it will update the snapshot file and never throw an error.}
 }
 \value{
-\code{NULL}. All test files are executed and errors are collected; if
-  any tests fail, a single error is thrown at the end with all failure
-  messages combined.
+\code{NULL}. All test files are executed and errors are collected; if any
+tests fail, a single error is thrown at the end with all failure messages
+combined.
 }
 \description{
 The tests are executed in a clean environment with the namespace of the
 package to be tested as the parent environment, which means you can use
 non-exported objects in the package without having to resort to the triple
-colon \code{\link{:::}} trick.
+colon \code{:::} trick.
 }
 \details{
-The tests are assumed to be under the \file{testit/} or \file{tests/testit/}
-directory by default (depending on your working directory is the package root
-directory or the \file{tests/} directory). The test scripts must be named of
-the form \samp{test-*.R} (or \samp{test-*.md} for snapshot tests); other
-files will not be treated as test files (but may also be useful, e.g. you can
-\code{\link{source}()} other scripts in tests).
+The tests are assumed to be under the \verb{testit/} or \verb{tests/testit/} directory
+by default (depending on your working directory is the package root directory
+or the \verb{tests/} directory). The test scripts must be named of the form
+\verb{test-*.R} (or \verb{test-*.md} for snapshot tests); other files will not be
+treated as test files (but may also be useful, e.g. you can \code{\link[=source]{source()}} other
+scripts in tests).
 
-Helper files named \samp{helper*.R} (e.g., \samp{helper.R},
-\samp{helper-utils.R}) are sourced before test files and remain available
-to all tests, allowing you to define shared utility functions.
+Helper files named \code{helper*.R} (e.g., \code{helper.R}, \code{helper-utils.R}) are
+sourced before test files and remain available to all tests, allowing you to
+define shared utility functions.
 
 When a test is executed, the working directory is the same as the directory
 containing this test, and all existing objects in the test environment will
 be removed before the code is executed (except for helper functions).
 
-See \url{https://pkg.yihui.org/testit/#snapshot-testing} for more details
-about snapshot testing.
+See \url{https://pkg.yihui.org/testit/#snapshot-testing} for more details about
+snapshot testing.
 }
 \note{
-The \pkg{testit} package must be loaded (e.g., via
-  \code{library(testit)}) before calling \code{test_pkg()}, because test
-  scripts typically call \code{\link{assert}()} and other \pkg{testit}
-  functions directly without the \code{testit::} prefix. Simply using
-  \code{testit::test_pkg()} without loading the package first will result in
-  errors like \dQuote{could not find function "assert"}.
+The \strong{testit} package must be loaded (e.g., via \code{library(testit)})
+before calling \code{test_pkg()}, because test scripts typically call
+\code{\link[=assert]{assert()}} and other \strong{testit} functions directly without the \verb{testit::}
+prefix. Simply using \code{testit::test_pkg()} without loading the package first
+will result in errors like "could not find function \"assert\"".
 
 All test scripts must be encoded in UTF-8 if they contain any multibyte
-  characters.
+characters.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary

- Rewrote README to be beginner-friendly: added a quick-start guide, clearer structure with step-by-step setup, and a focused comparison with testthat.
- Improved roxygen documentation for `assert()`, `test_pkg()`, and `has_message()`/`has_warning()`/`has_error()` to be more intuitive and easier to understand.
- Expanded DESCRIPTION to describe all package features (was only mentioning `assert()` and `test_pkg()`).
- Fixed a bug where `ignore.case = TRUE` was silently ignored in `has_message()`, `has_warning()`, and `has_error()` because `fixed = TRUE` (the default) takes precedence in `grepl()`. Now `ignore.case = TRUE` automatically disables fixed matching.

## Test plan

- [x] `R CMD check` passes with Status: OK
- [x] All existing tests pass, including the `ignore.case` tests that were previously failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)