### PR TITLE
Don't reinstall the package under covr or on repeated test_pkg() calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: testit
 Type: Package
 Title: A Simple Package for Testing R Packages
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
   person("Tomas", "Kalibera", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,8 @@
 # CHANGES IN testit VERSION 1.2
 
+- `test_pkg()` no longer reinstalls the package when it is run under `covr` (detected via the `R_COVR` environment variable), and installs the package at most once per session so that repeated `test_pkg()` calls (e.g. a CRAN suite plus a CI-only suite in `tests/test-all.R`) reuse the first install. Previously the reinstall clobbered `covr`'s instrumented build, breaking coverage with errors such as `undefined symbol: __gcov_merge_add` (#28).
 
 # CHANGES IN testit VERSION 1.1
-
-- `test_pkg()` no longer reinstalls the package when it is run under `covr` (detected via the `R_COVR` environment variable), and installs the package at most once per session so that repeated `test_pkg()` calls (e.g. a CRAN suite plus a CI-only suite in `tests/test-all.R`) reuse the first install. Previously the reinstall clobbered `covr`'s instrumented build, breaking coverage with errors such as `undefined symbol: __gcov_merge_add` (#28).
 
 - `test_pkg()` now sources global helper files (`helper*.R`) from the parent directory of the test directory before sourcing helpers in the test subdirectory itself. This allows sharing common test utilities across multiple test subdirectories (e.g., `tests/testit/`, `tests/test-cran/`).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN testit VERSION 1.1
 
+- `test_pkg()` no longer reinstalls the package when it is run under `covr` (detected via the `R_COVR` environment variable), and installs the package at most once per session so that repeated `test_pkg()` calls (e.g. a CRAN suite plus a CI-only suite in `tests/test-all.R`) reuse the first install. Previously the reinstall clobbered `covr`'s instrumented build, breaking coverage with errors such as `undefined symbol: __gcov_merge_add` (#28).
+
 - `test_pkg()` now sources global helper files (`helper*.R`) from the parent directory of the test directory before sourcing helpers in the test subdirectory itself. This allows sharing common test utilities across multiple test subdirectories (e.g., `tests/testit/`, `tests/test-cran/`).
 
 # CHANGES IN testit VERSION 1.0

--- a/R/testit.R
+++ b/R/testit.R
@@ -217,10 +217,16 @@ test_pkg = function(package = pkg_name(), dir = NULL, filter = NULL, update = NA
   if (missing(filter)) filter = args$filter
   if (missing(update)) update = args$update
   # install the source package before running tests when this function is called
-  # in a non-interactive R session that is not `R CMD check`
+  # in a non-interactive R session in which the package has not already been
+  # installed by a harness (`R CMD check` sets `_R_CHECK_PACKAGE_NAME_`, and
+  # covr installs an instrumented build and sets `R_COVR`; reinstalling would
+  # clobber it), and has not already been installed in this session by an
+  # earlier test_pkg() call (multiple calls should install at most once)
   pkg_root = if (file.exists('DESCRIPTION')) '.' else if (file.exists('../DESCRIPTION')) '..'
   install = !interactive() &&
     is.na(Sys.getenv('_R_CHECK_PACKAGE_NAME_', NA)) &&
+    is.na(Sys.getenv('R_COVR', NA)) &&
+    !(package %in% .env$installed) &&
     !is.null(pkg_root) && package == pkg_name() &&
     pkg_needs_install(pkg_root, package)
   if (install) {
@@ -241,6 +247,8 @@ test_pkg = function(package = pkg_name(), dir = NULL, filter = NULL, update = NA
       .libPaths(c(lib_new, lib_old))
       if (!is.na(i <- match(paste0('package:', package), search())))
         detach(pos = i, unload = TRUE, force = TRUE)
+      # remember it so later test_pkg() calls in this session don't reinstall
+      .env$installed = c(.env$installed, package)
       'Done.'
     } else 'Failed.')
   }


### PR DESCRIPTION
## Problem

`test_pkg()` installs the source package before running tests, skipping this only under `R CMD check` (detected via `_R_CHECK_PACKAGE_NAME_`).

Under **covr**, `_R_CHECK_PACKAGE_NAME_` is unset, so `test_pkg()` reinstalled a **non-instrumented** build into a temporary library and prepended it to `.libPaths()`. That clobbered the gcov-instrumented build covr had set up, so reading coverage failed with:

```
undefined symbol: __gcov_merge_add
```

or, when covr later walked the package sources:

```
cannot open file '.../R-lib-XXXX/<pkg>/R/<pkg>.rdb': No such file or directory
```

A package that calls `test_pkg()` twice from `tests/test-all.R` (e.g. a CRAN suite plus a CI-only suite gated on `CI=true`) makes this reliably reproducible; packages calling it once could escape by mtime/namespace luck.

## Fix

- Skip the reinstall when covr is in charge (it sets `R_COVR`), mirroring the existing `R CMD check` guard.
- Install at most once per session (tracked in `.env$installed`), so subsequent `test_pkg()` calls reuse the first install instead of repeating it.

## Testing

- `covr::package_coverage()` on a package with two `test_pkg()` calls now succeeds (previously errored).
- A plain non-interactive run still installs once and runs both suites.
- testit's own `test_pkg("testit")` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)